### PR TITLE
Implement `AsRawHandle` for serial `Connection`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ use std::ffi::CString;
 use std::{ ptr, mem, io };
 use std::io::{ Error, ErrorKind };
 use std::cell::RefCell;
+use std::os::windows::io::{AsRawHandle, RawHandle};
 
 mod ffi;
 
@@ -293,6 +294,11 @@ impl Drop for Connection {
 		if e == 0 {
 			panic!("Drop of Connection failed. CloseHandle gave error 0x{:x}", e)
 		}
+	}
+}
+impl AsRawHandle for Connection {
+	fn as_raw_handle(&self) -> RawHandle {
+		*self.comm_handle.borrow() as RawHandle
 	}
 }
 unsafe impl Send for Connection { }


### PR DESCRIPTION
Standard library provides the `std::os::windows::io::AsRawHandle` trait to obtain a windows handle from a IO device. Then such handle can be used to perform low level actions. 

It would be great if `Connection` also implements such trait. I kindly request you to apply this patch to your codebase and release a new version of the crate. 

Many thanks for this crate and your time!
